### PR TITLE
Chainguard Container Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ---------- Builder ----------
-FROM golang:1.24-alpine AS builder
+FROM cgr.dev/chainguard/go:latest AS builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -trimpath -ldflags="-s -w" -o /app/rr-dnsd ./cmd/rr-dnsd
 
 # ---------- Runtime ----------
-FROM gcr.io/distroless/static:nonroot
+FROM cgr.dev/chainguard/static:latest
 
 # OCI labels
 LABEL org.opencontainers.image.title="rr-dns" \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CMD_DIR=./cmd/rr-dnsd
 
 .PHONY: all build test bench fmt vet lint clean ci
 
-all: build
+all: clean fmt vet test lint sec build
 
 build:
 	go build -o $(BINARY_NAME) $(CMD_DIR)
@@ -31,9 +31,6 @@ sec:
 clean:
 	go clean
 	rm -f $(BINARY_NAME)
-
-
-ci: fmt vet lint test
 
 cover:
 	go test -coverprofile=cover.out ./...


### PR DESCRIPTION
Migrate to Chainguard container images which provide secure software supply chain and CVE mitigation. This addresses issues where other public static/nonroot containers were obsolete. 